### PR TITLE
Added rvm fix to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ This currently doesn't cover Rspec or MiniTest::Spec style files, but support is
 * `cmd-ctrl-e` - Re-run the previous test file
 * `cmd-ctrl-x` - Show/hide the test panel
 
+## RVM
+
+If you are using RVM then you need to make sure Atom is loaded via env so that it has access to your `$PATH`. Otherwise you will get an error like `execvp(): No such file or directory`.
+
+	vim `which atom`
+
+Change:
+
+	open -a $ATOM_PATH -n --args --executed-from="$(pwd)" --pid=$$ $@
+
+to:
+
+	env open -a $ATOM_PATH -n --args --executed-from="$(pwd)" --pid=$$ $@
+
 ## Todo
 
 * Tests!


### PR DESCRIPTION
Added information to the README explaining how to fix the rvm issue I encountered in issue #2.

I'm happy to put the information somewhere else if you don't think that is should go on the homepage README but as there are a lot of Rubyists who use rvm I figured it was OK.
