### PR TITLE
Spawn an interactive shell rather than call execvp()

### DIFF
--- a/lib/test_runner.coffee
+++ b/lib/test_runner.coffee
@@ -1,4 +1,5 @@
 {BufferedProcess} = require 'atom'
+ChildProcess = require 'child_process'
 
 class TestRunner
   args: ['-I', 'test']
@@ -31,8 +32,19 @@ class TestRunner
 
   runTests: ->
     @testResult = ''
-    new @process @processParams()
+    @runCommand(@processParams())
     @returnCallback()
+
+  runCommand: (params) ->
+    command = "#{params.command} #{params.args}"
+    spawn = ChildProcess.spawn
+    terminal = spawn("bash", ["-l"])
+    terminal.on 'close', params.exit
+    terminal.stdout.on 'data', params.stdout
+    terminal.stderr.on 'data', params.stderr
+    terminal.stdin.write("cd #{params.options.cwd} && #{command}\n")
+    terminal.stdin.write("exit\n")
+
 
 class RspecTestRunner extends TestRunner
   command: 'rspec'

--- a/lib/test_runner.coffee
+++ b/lib/test_runner.coffee
@@ -18,30 +18,49 @@ class TestRunner
     @returnCallback()
 
   processParams: ->
-    command: "bash"
-    args: ["-l"]
-    options:
-      cwd: atom.project.getPath()
-    stdout: @collectResults
-    stderr: @collectResults
-    exit: @exit
+    command: @fullCommand(),
+    cwd:     atom.project.getPath(),
+    stdout:  @collectResults,
+    stderr:  @collectResults,
+    exit:    @exit
 
   returnCallback: =>
     @callback(@testFile, @testResult)
 
   runTests: ->
     @testResult = ''
-    @executeProcess()
+    ProcessRunner.run(@processParams())
     @returnCallback()
-
-  executeProcess: ->
-    process = new @processClass @processParams()
-    stdin = process.process.stdin
-    stdin.write "#{@fullCommand()} && exit\n"
 
   fullCommand: ->
     args = @args.concat(@testFile)
     "#{@command} #{args}"
+
+class ProcessRunner
+  @run: (opts) ->
+    p = new ProcessRunner(opts)
+    p.run()
+
+  constructor: (opts) ->
+    @cwd = opts.cwd
+    @command = opts.command
+    @stdout = opts.stdout
+    @stderr = opts.stderr
+    @exit = opts.exit
+
+  run: ->
+    p = new BufferedProcess(@processParams())
+    stdin = p.process.stdin
+    stdin.write "#{@command} && exit\n"
+
+  processParams: ->
+    command: "bash"
+    args: ["-l"]
+    options:
+      cwd: @cwd
+    stdout: @stdout
+    stderr: @stderr
+    exit: @exit
 
 class RspecTestRunner extends TestRunner
   command: 'rspec'
@@ -53,5 +72,6 @@ class CucumberTestRunner extends TestRunner
 
 module.exports =
   TestRunner: TestRunner
+  ProcessRunner: ProcessRunner
   RspecTestRunner: RspecTestRunner
   CucumberTestRunner: CucumberTestRunner

--- a/lib/test_runner.coffee
+++ b/lib/test_runner.coffee
@@ -3,7 +3,6 @@
 class TestRunner
   args: ['-I', 'test']
   command: 'ruby'
-  processClass: BufferedProcess
 
   constructor: (testFile, callback)->
     @testResult = ''

--- a/spec/test-runner-spec.coffee
+++ b/spec/test-runner-spec.coffee
@@ -1,6 +1,5 @@
 {BufferedProcess} = require 'atom'
-testRunnerNamespace = require '../lib/test_runner'
-{TestRunner, ProcessRunner} = testRunnerNamespace
+{TestRunner, ProcessRunner} = require '../lib/test_runner'
 
 describe "TestRunner", ->
 

--- a/spec/test-runner-spec.coffee
+++ b/spec/test-runner-spec.coffee
@@ -1,5 +1,6 @@
 {BufferedProcess} = require 'atom'
-{TestRunner}      = require '../lib/test_runner'
+testRunnerNamespace = require '../lib/test_runner'
+{TestRunner, ProcessRunner} = testRunnerNamespace
 
 describe "TestRunner", ->
 
@@ -18,10 +19,8 @@ describe "TestRunner", ->
   describe '::processParams', ->
     it 'contains a parameters object', ->
       object =
-        command: @runner.command
-        args: @runner.args.concat(@runner.testFile)
-        options:
-          cwd: atom.project.getPath()
+        command: @runner.fullCommand()
+        cwd: atom.project.getPath()
         stdout: @runner.collectResults
         stderr: @runner.collectResults
         exit: @runner.exit
@@ -40,11 +39,10 @@ describe "TestRunner", ->
       expect(@runner.returnCallback).toHaveBeenCalled()
 
   describe '::runTests', ->
-
-    it "creates a BufferedProcess", ->
-      spyOn @runner, 'process'
+    it "runs a ProcessRunner", ->
+      spyOn(ProcessRunner, 'run').andCallThrough()
       @runner.runTests()
-      expect(@runner.process).toHaveBeenCalledWith @runner.processParams()
+      expect(ProcessRunner.run).toHaveBeenCalledWith(@runner.processParams())
 
     it "resets the ::testResult string", ->
       @runner.testResult = "Previous test results"


### PR DESCRIPTION
## What

Solve for a number of environment issues when running the tests.

Includes solution for running tests in an RVM environment, identified in Issue #2 and PR #3, and should work with other Ruby version managers. This change  necessitates further changes to `lib/test_runner.coffee` and `README.md`, to be determined. I modeled this approach from https://github.com/fcoury/atom-rspec.
